### PR TITLE
Improve code logic and fix errors

### DIFF
--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -38,7 +38,6 @@ def initialize_vmmap_hashmap():
     Downloads ALL remote files from remote and creates a hashmap
     to be used for comparing and using the correct binary to get
     base_address."""
-
     global hashmap
 
     vmmap = get_process_maps()

--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -40,7 +40,7 @@ def rebase_addr(addr, up=False):
     down -> make an absolute address to an offset
     """
     vmmap = get_process_maps()
-    base_address = min([x.page_start for x in vmmap if x.path == get_filepath()])
+    base_address = min([x.page_start for x in vmmap if x.path.split('/')[-1] == get_filename()])
     checksec_status = checksec(get_filepath())
     pie = checksec_status["PIE"]  # if pie we will have offset instead of abs address.
     corrected_addr = addr
@@ -207,7 +207,7 @@ class SymbolMapper:
 
         # locate the base address of the binary
         vmmap = get_process_maps()
-        text_base = min([x.page_start for x in vmmap if x.path == get_filepath()])
+        text_base = min([x.page_start for x in vmmap if x.path.split('/')[-1] == get_filename()])
 
         # add each symbol into a mass symbol commit
         max_commit_size = 1500

--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -472,7 +472,7 @@ class GEFDecompilerClient(DecompilerClient):
         args = func_data["args"]
         stack_vars = func_data["stack_vars"]
 
-        for idx, arg in args.items():
+        for idx, arg in list(args.items())[:len(current_arch.function_parameters)]:
             idx = int(idx, 0)
             expr = f"""(({arg['type']}) {current_arch.function_parameters[idx]}"""
             try:

--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -221,12 +221,13 @@ class SymbolMapper:
 
         # locate the base address of the binary
         vmmap = get_process_maps()
-        
-        if is_remote_debug():
+ 
+        global downloaded
+        if is_remote_debug() and downloaded == False:
             global hashmap
-            # CHECK IF DOWNLOADED BEFORE!!
+            downloaded = True
             hashmap = {}
-            for path in [x.path for x in vmmap]:
+            for path in set([x.path for x in vmmap]):
                 if path == '' or path == '[heap]' or path == '[stack]':
                     continue
                 out = download_file(path)
@@ -245,7 +246,7 @@ class SymbolMapper:
                     text_base = min(text_base_arr)
         elif not is_remote_debug():
             text_base = min([x.page_start for x in vmmap if x.path == get_filepath()])
-        
+
 
 
         # add each symbol into a mass symbol commit
@@ -639,6 +640,8 @@ class DecompilerCommand(GenericCommand):
             self._handler_failed("not enough args")
             return
 
+        global downloaded
+        downloaded = False
         name = args[0]
         host = "localhost"
         port = 3662
@@ -682,7 +685,7 @@ class DecompilerCommand(GenericCommand):
             [] connect <name> (host) (port)
                 Connects the decomp2gef plugin to the decompiler. After a successful connect, a decompilation pane
                 will be visible that will get updated with global decompiler info on each break-like event.
-                
+
                 * name = name of the decompiler, can be anything
                 * host = host of the decompiler; will be 'localhost' if not defined
                 * port = port of the decompiler; will be 3662 if not defined

--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -425,6 +425,9 @@ class GEFDecompilerClient(DecompilerClient):
         return self.function_headers
 
     def update_function_data(self, addr):
+        if current_arch.arch == 'X86':
+            #: ugly hardcoding hack
+            current_arch.function_parameters = [f'$esp+{x}' for x in range(0, 28, 4)]
         func_data = self.function_data(addr)
         args = func_data["args"]
         stack_vars = func_data["stack_vars"]


### PR DESCRIPTION
## This PR aims to address a few issues in decomp2gef

### First issue addressed

As of now, if you try to connect decompiler to debug a binary over a remote server via gdbserver, chances are you will encounter the error `min() arg is an empty sequence` which arises due to the following lines

```py
base_address = min([x.page_start for x in vmmap if x.path == get_filepath()])
...
text_base = min([x.page_start for x in vmmap if x.path == get_filepath()])
```

This arises due to inconsistency in the exact path of the binary between the remote server and the local binary. 

For example, if I try to debug a binary on remote with file path `/bin/program` with the local binary in `/tmp/program`, x.path will return `/bin/program` and `get_filepath()` will return `/tmp/program` which does not match and causes the array to be empty.\

Hence a slight modification to compare the file name rather than the absolute path will solve this issue.

```py
base_address = min([x.page_start for x in vmmap if x.path.split('/')[-1] == get_filename()])
...
text_base = min([x.page_start for x in vmmap if x.path.split('/')[-1] == get_filename()])
```

### Second issue addressed

```py
def update_function_data(self, addr):
    ...
    for idx, arg in args.item():
        idx = int(idx, 0)
        expr = f"""(({arg['type']}) {current_arch.function_parameters[idx]}"""
    ...
```

Within the update_function_data(), we use `current_arch.function_parameters` to get the registers in which our function arguments are stored and use IDX to match the argument to the respective register/place in memory where the argument is stored.

In x86_64, `current_arch.function_parameters = ['$rdi', '$rsi', '$rdx', '$rcx', '$r8', '$r9']` and this works for functions with 6 arguments as `current_arch.function_parameters[0]` will match argument 1 to $rdi and so on. 

The flaw comes when we fail to consider functions with 7 or more arguments where arguments will then be found in the stack. 

However we can set this aside, for now, we don't usually encounter more than 7 arguments, right?

The more urgent flaw is when we bring in the X86 architecture.

In x86, `current_arch.function_parameters = ['$esp']`. This means that beyond the first argument, decomp2gef will break with an IndexError as it tries to access `current_arch.function_parameters[1]` for the 2nd argument and so on.

I'm not sure if there's a nice way to do this but I essentially redefined `current_arch.function_parameters` for X86 architectures. 

```py
current_arch.function_parameters = [f'$esp+{x}' for x in range(0, 28, 4)]
```

This allows decomp2gef to work, but I haven't considered implications yet as it may get pretty complicated(?)

I welcome any ideas!!