### PR TITLE
Fix symbol size offsets/Designate appropriate symbol size to symbols

### DIFF
--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -400,7 +400,7 @@ class SymbolMapper:
                 continue
 
             # compute offset
-            sym_size_loc = tab_offset + sym_data_size * (i + 5) + sym_size_off
+            sym_size_loc = tab_offset + sym_data_size * (i + 1) + sym_size_off
             pack_str = "<Q" if elf.ELF_64_BITS else "<I"
             # write the new size
             updated_size = struct.pack(pack_str, size)


### PR DESCRIPTION
Addresses #15, took a while to debug but on comparing `queued_sym_sizes` to `sym_info_list`, they seemed to be correct and match accordingly.

I tested this PR against very basic 32 and 64 bit binaries, which both seems to give me the appropriate symbol sizes upon calling `readelf`. 

Do have a look! Unfortunately, does not fix #14 :(