### PR TITLE
add checks when forcing text size

### DIFF
--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -382,7 +382,6 @@ class SymbolMapper:
         # patch .text to seem large enough for any function
         if elf.e_class == Elf.ELF_64_BITS:
             elf_data = self._force_update_text_size(elf_data, 0xFFFFFF)
-        else:
             pass
 
         # find the symbol table

--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -382,7 +382,6 @@ class SymbolMapper:
         # patch .text to seem large enough for any function
         if elf.e_class == Elf.ELF_64_BITS:
             elf_data = self._force_update_text_size(elf_data, 0xFFFFFF)
-            pass
 
         # find the symbol table
         for section in elf.shdrs:

--- a/decomp2gef.py
+++ b/decomp2gef.py
@@ -380,7 +380,10 @@ class SymbolMapper:
         elf_data = bytearray(open(fname, "rb").read())
 
         # patch .text to seem large enough for any function
-        elf_data = self._force_update_text_size(elf_data, 0xFFFFFF)
+        if elf.e_class == Elf.ELF_64_BITS:
+            elf_data = self._force_update_text_size(elf_data, 0xFFFFFF)
+        else:
+            pass
 
         # find the symbol table
         for section in elf.shdrs:


### PR DESCRIPTION
Previously, we force text_size to 0xFFFFFF with a nasty hack which only works on 64 bit binaries.

This means that 32-bit binaries will throw a .strtab offset error or something along those times most of the time which is rather ugly.

Hence we implement a bit check on the binary and enforce the hack if binary is 64-bit. We should definitely implement a nicer method that caters to 32-bit binaries when possible, but until then these will suffice to preserve sanity.

addresses #14 !!